### PR TITLE
Solving Mac OSX install and runtime issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,25 @@ Populous is a tool for fast and rich data generation. From a description of your
 
 ## Current state
 The project is in a very early stage and proof-of-concept state. Please be patient, but don't hesitate to share your thoughts and desires with us in the issues.
+
+## Troubleshooting
+
+### OSX compilation problems
+
+There's currently no pre-compiled package for the ``peloton_bloomfilters`` library, which is a current requirement for populous. To correctly install it in your environment, you're going to:
+
+
+* install ``gcc`` (via homebrew, for example),
+* install the package using the following flags ``ARCHFLAGS="-arch x86_64" CC=/usr/bin/gcc``.
+
+For example, to install locally:
+
+```
+ARCHFLAGS="-arch x86_64" CC=/usr/bin/gcc pip install peloton_bloomfilters
+```
+
+Or if you want to run the test suite via tox:
+
+```
+ARCHFLAGS="-arch x86_64" CC=/usr/bin/gcc tox
+```

--- a/populous/generators/date.py
+++ b/populous/generators/date.py
@@ -1,7 +1,7 @@
 import random
 from datetime import date
 from datetime import datetime
-from time import mktime
+from time import mktime, gmtime
 
 from dateutil.parser import parse as dateutil_parse
 from dateutil.tz import tzlocal
@@ -29,6 +29,8 @@ def parse_datetime(candidate):
 
 class DateTime(Generator):
 
+    epoch_year = gmtime(0).tm_year
+
     def get_arguments(self, past=True, future=False, after=None, before=None,
                       **kwargs):
         super(DateTime, self).get_arguments(**kwargs)
@@ -43,7 +45,7 @@ class DateTime(Generator):
             start = to_timestamp(datetime.now())
         else:
             # try not to go too far in the past
-            start = to_timestamp(datetime(1900, 1, 1))
+            start = to_timestamp(datetime(self.epoch_year, 1, 1))
 
         if self.future:
             # try not to go too far in the future

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,5 +1,7 @@
 import socket
 from itertools import islice
+from datetime import datetime
+from contextlib import contextmanager
 
 import pytest
 
@@ -9,6 +11,15 @@ from populous.exceptions import ValidationError
 from populous import generators
 from populous.generators.base import NullableMixin
 from populous.generators.base import UniquenessMixin
+from populous.generators.date import to_timestamp
+
+
+@contextmanager
+def not_raises(exception):
+    try:
+        yield
+    except exception:
+        raise pytest.fail("DID RAISE {0}".format(exception))
 
 
 def take(generator, length=100):
@@ -437,6 +448,14 @@ def test_date(blueprint, item):
     months = set(e.month for e in sample)
     for month in range(1, 12):
         assert month in months
+
+
+def test_epoch():
+    with not_raises(OverflowError):
+        to_timestamp(datetime(generators.DateTime.epoch_year, 1, 1))
+
+    with not_raises(OverflowError):
+        to_timestamp(datetime(generators.Date.epoch_year, 1, 1))
 
 
 def test_name(item):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,py7-django{18,19,110,stable},flake8
 skipsdist = True
 
 [testenv]
+passenv = ARCHFLAGS CC
 deps =
     pytest-cov
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
1 - Solving the compilation issue for the `peloton_bloomfilters` library

* Adding docs about troubleshooting using OSX
* Passing the right environment variables in the `tox.ini` file to ensure tox execution

2 - Solving the "epoch" issue

This might not be an OSX-specific issue solved here.
Since the `epoch` time is varying according to the platform, it looked like that on OSX the epoch was starting at 1970. Instead of filling the year manually, I've chosen to use the ``gmtime(0).tm_year``, loaded as a class property to make sure it's computed only once.

It has solved the problem on my machine, I hope it didn't break anything on other environments, but I'm confident. It also makes sure that we'll be using the appropriate epoch year on any platform.