### PR TITLE
Use peloton_bloomfilter in all Python versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Changelog
 
 - Fix unicode error in exceptions with Python 2
 - Fix error with buffers (#35)
+- Use peloton_bloomfilters_py3 with all Python versions
 
 
 0.2.2 (2017-09-12)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Fix unicode error in exceptions with Python 2
+- Fix error with buffers (#35)
 
 
 0.2.2 (2017-09-12)

--- a/populous/bloom.py
+++ b/populous/bloom.py
@@ -1,4 +1,4 @@
-from .compat import bloomfilter
+import peloton_bloomfilters as bloomfilter
 
 
 class BloomFilter(object):

--- a/populous/compat.py
+++ b/populous/compat.py
@@ -9,12 +9,6 @@ PY2 = sys.version_info[0] == 2
 
 
 if PY2:
-    import peloton_bloomfilters as bloomfilter
-else:
-    import pybloomfilter as bloomfilter
-
-
-if PY2:
     from string import letters as ascii_letters
 else:
     from string import ascii_letters
@@ -23,7 +17,6 @@ else:
 __all__ = [
     'ascii_letters',
     'basestring',
-    'bloomfilter',
     'PY2',
     'range',
     'zip',

--- a/setup.py
+++ b/setup.py
@@ -19,19 +19,11 @@ requirements = [
     "future",
     "Jinja2",
     "PyYAML",
+    "peloton_bloomfilters_py3"
 ]
 
 if sys.version_info < (3, 2):
     requirements.append('functools32')
-
-if sys.version_info < (3,):
-    requirements.append('peloton_bloomfilters')
-else:
-    requirements += [
-        'cython',
-        'pybloomfiltermmap3',
-    ]
-
 
 setup(
     name="populous",

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -153,7 +153,7 @@ def test_blueprint_generate(mocker):
     if PY2:
         assert lol.generate.call_args == mocker.call(buffer, 17)
     else:
-        assert lol.generate.call_args == mocker.call(buffer, 15)
+        assert lol.generate.call_args == mocker.call(buffer, 20)
     assert buffer.flush.called is True
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipsdist = True
 passenv = ARCHFLAGS CC
 deps =
     pytest-cov
-    py36: cython
     django18: Django>=1.8,<1.9
     django111: Django>=1.11,<1.12
     djangostable: Django


### PR DESCRIPTION
We add issues with the pybloomfiltermmap3 (error with libcrypto and compilation issues linked to Cython).

I've created a fork of peloton_bloomfilter in order to support Python 3. Hopefully it will get merged upstream (https://github.com/pelotoncycle/peloton_bloomfilters/pull/4).
