### PR TITLE
Use environment marker for functools32

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 0.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use environment markers for functools32 dependency
 
 
 0.4.0 (2018-05-25)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup, find_packages
 
 import populous
@@ -22,8 +20,6 @@ requirements = [
     "peloton_bloomfilters_py3"
 ]
 
-if sys.version_info < (3, 2):
-    requirements.append('functools32')
 
 setup(
     name="populous",
@@ -38,6 +34,7 @@ setup(
     install_requires=requirements,
     extras_require={
         'tests': ['tox', 'pytest', 'pytest-mock', 'flake8'],
+        ':python_version<"3.2"': ['functools32'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The conditional dependency was causing issues, as sometimes functools32 was considered as a dependency with Python > 3.2 (for example with Pipenv).