### PR TITLE
Store intermediate values with 'store_in'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 0.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Store intermediate values with 'store_in'
 
 
 0.4.1 (2018-05-28)


### PR DESCRIPTION
This is useful if you need to use a stored value which wasn't committed yet. For example if you have two items generated by the same item, and one is needing information from the other during the generation.

cc @entwanne 